### PR TITLE
ci: ensure future versions are published to PAC

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,5 +114,10 @@
     "remove": [
       "engines"
     ]
+  },
+  "publishConfig": {
+    "access": "restricted",
+    "registry": "https://packages.atlassian.com/api/npm/atlassian-npm/",
+    "@loomhq/registry": "https://packages.atlassian.com/api/npm/atlassian-npm/"
   }
 }


### PR DESCRIPTION
All @loomhq packages are being published to packages.atlassian.com in the future. This PR adds a publishConfig to ensure that happens.